### PR TITLE
feat: add Tag create API & fix Live create API

### DIFF
--- a/src/apis/lives/dto/create-live.dto.ts
+++ b/src/apis/lives/dto/create-live.dto.ts
@@ -1,7 +1,11 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsArray, IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateLiveDto {
   @IsNotEmpty()
   @IsString()
   title: string;
+
+  @IsNotEmpty()
+  @IsArray()
+  tagNames: string[];
 }

--- a/src/apis/lives/lives.module.ts
+++ b/src/apis/lives/lives.module.ts
@@ -4,9 +4,10 @@ import { LivesController } from './lives.controller';
 import { LivesService } from './lives.service';
 import { ChannelsModule } from 'src/apis/channels/channels.module';
 import { Live } from './entities/live.entity';
+import { TagsModule } from '../tags/tags.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Live]), ChannelsModule],
+  imports: [TypeOrmModule.forFeature([Live]), ChannelsModule, TagsModule],
   controllers: [LivesController],
   providers: [LivesService],
 })

--- a/src/apis/lives/lives.service.ts
+++ b/src/apis/lives/lives.service.ts
@@ -4,6 +4,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { CreateLiveDto } from './dto/create-live.dto';
 import { ChannelsService } from 'src/apis/channels/channels.service';
 import { Live } from './entities/live.entity';
+import { TagsService } from '../tags/tags.service';
+import { CreateTagDto } from '../tags/dto/create-tag.dto';
 
 @Injectable()
 export class LivesService {
@@ -11,14 +13,17 @@ export class LivesService {
     @InjectRepository(Live)
     private readonly livesRepository: Repository<Live>,
     private readonly channelsService: ChannelsService,
+    private readonly tagsService: TagsService,
   ) {}
 
   async createLive({ userId, createLiveDto }: ILivesServiceCreateLive) {
+    const { title, ...createTagDto } = createLiveDto;
     const channel = await this.channelsService.findByUserId({ userId });
-
+    const tags = await this.tagsService.createTags({ createTagDto });
     const live = await this.livesRepository.save({
-      title: createLiveDto.title,
+      title,
       channel: { id: channel.id },
+      tags,
     });
     return live;
   }

--- a/src/apis/tags/dto/create-tag.dto.ts
+++ b/src/apis/tags/dto/create-tag.dto.ts
@@ -1,0 +1,7 @@
+import { IsArray, IsNotEmpty } from 'class-validator';
+
+export class CreateTagDto {
+  @IsNotEmpty()
+  @IsArray()
+  tagNames: string[];
+}

--- a/src/apis/tags/tags.controller.ts
+++ b/src/apis/tags/tags.controller.ts
@@ -1,0 +1,18 @@
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { TagsService } from './tags.service';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { AccessAuthGuard } from '../auth/guard/auth.guard';
+
+@Controller('api/tags')
+export class TagsController {
+  constructor(private readonly tagsService: TagsService) {}
+
+  @UseGuards(AccessAuthGuard)
+  @Post()
+  async createTags(@Body() createTagDto: CreateTagDto) {
+    const tags = await this.tagsService.createTags({
+      createTagDto,
+    });
+    return tags;
+  }
+}

--- a/src/apis/tags/tags.module.ts
+++ b/src/apis/tags/tags.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Tag } from './entities/tag.entity';
+import { TagsController } from './tags.controller';
+import { TagsService } from './tags.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Tag])],
+  controllers: [TagsController],
+  providers: [TagsService],
+  exports: [TagsService],
+})
+export class TagsModule {}

--- a/src/apis/tags/tags.service.ts
+++ b/src/apis/tags/tags.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Tag } from './entities/tag.entity';
+import { In, Repository } from 'typeorm';
+import { CreateTagDto } from './dto/create-tag.dto';
+
+@Injectable()
+export class TagsService {
+  constructor(
+    @InjectRepository(Tag)
+    private readonly tagsRepository: Repository<Tag>,
+  ) {}
+
+  /**
+   * 태그 생성 시 태그들을 배열 형태로 출력합니다.
+   * 태그가 존재하면 기존에 것을 쓰고, 없으면 생성합니다.
+   * 기존 태그는 updatedAt을 최신화합니다.
+   * 이는 현재 날짜와 비교해서 사용되지 않는 태그(유행지난 태그)를 구분하는데 활용됩니다.
+   */
+  async createTags({ createTagDto }: ITagsServiceCreateTag): Promise<Tag[]> {
+    const tags = [];
+    const { tagNames } = createTagDto;
+    for (let i = 0; i < tagNames.length; i++) {
+      const name = tagNames[i];
+      let tag = await this.tagsRepository.findOneBy({ name }); // 태그가 있는지 확인
+      if (!tag) {
+        tag = await this.tagsRepository.save({ name }); // 없으면 생성
+      } else {
+        tag.updatedAt = new Date(); // 있으면 날짜 업데이트
+        this.tagsRepository.save(tag);
+      }
+      tags.push(tag); // 태그 결과를 배열에 담기
+    }
+    return tags;
+  }
+}
+
+interface ITagsServiceCreateTag {
+  createTagDto: CreateTagDto;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from './apis/auth/auth.module';
 import { CategoriesModule } from './apis/categories/cetegories.module';
 import { ChannelsModule } from './apis/channels/channels.module';
 import { LivesModule } from './apis/lives/lives.module';
+import { TagsModule } from './apis/tags/tags.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { LivesModule } from './apis/lives/lives.module';
     CategoriesModule,
     ChannelsModule,
     LivesModule,
+    TagsModule,
     UsersModule,
     ConfigModule.forRoot(),
     TypeOrmModule.forRoot({


### PR DESCRIPTION
### 태그 생성 API를 구현했습니다.
- 태그 name을 배열 형태로 받습니다.
- 태그 생성 시 이미 존재하는 태그라면 기존 태그를 사용합니다.
- 기존 태그 사용 시 해당 태그의 updated_at을 최신화 합니다. 
### 라이브 방송 생성 시 태그 및 방송-태그 row가 함께 생성됩니다.
- 방송 시작 전 태그들을 프론트에 입력해 두고 방송 시작 클릭하면
- 방송, 태그, 방송-태그 테이블에 데이터가 생성됩니다.