### PR TITLE
fix: live income logic

### DIFF
--- a/src/apis/lives/lives.controller.ts
+++ b/src/apis/lives/lives.controller.ts
@@ -59,7 +59,7 @@ export class LivesController {
   async getLiveIncome(
     @User() user: UserAfterAuth,
     @Query() dateReqDto: DateReqDto,
-  ) {
+  ): Promise<{ income: number }> {
     const income = await this.livesService.getLiveIncome({
       userId: user.id,
       dateReqDto,

--- a/src/apis/lives/lives.service.ts
+++ b/src/apis/lives/lives.service.ts
@@ -114,8 +114,15 @@ export class LivesService {
       .createQueryBuilder('live')
       .select('SUM(live.income)', 'income')
       .leftJoin('live.channel', 'channel')
-      .where(`channel.id = :channelId`, { channelId: channel.id, year, month })
+      .where(`channel.id = :channelId`, {
+        channelId: channel.id,
+        year,
+        month,
+      })
       .getRawOne();
+    if (result.income === null) {
+      result.income = 0;
+    }
     return result;
   }
 


### PR DESCRIPTION
후원이 없을 경우 null값을 가지므로 SUM 연산이 정상 작동하지 않음
null값일 경우 0으로 변환하는 로직 추가